### PR TITLE
Use absl::string_view instead of std::string_view.

### DIFF
--- a/gutil/BUILD.bazel
+++ b/gutil/BUILD.bazel
@@ -90,23 +90,20 @@ cc_test(
 cc_library(
     name = "testing",
     testonly = True,
-    hdrs = [
-        "testing.h",
-    ],
+    hdrs = ["testing.h"],
     visibility = ["//visibility:public"],
     deps = [
         ":proto",
         ":status",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
     ],
 )
 
 cc_library(
     name = "collections",
-    hdrs = [
-        "collections.h",
-    ],
+    hdrs = ["collections.h"],
     visibility = ["//visibility:public"],
     deps = [
         ":status",
@@ -121,17 +118,14 @@ cc_library(
 
 cc_library(
     name = "proto",
-    srcs = [
-        "proto.cc",
-    ],
-    hdrs = [
-        "proto.h",
-    ],
+    srcs = ["proto.cc"],
+    hdrs = ["proto.h"],
     visibility = ["//visibility:public"],
     deps = [
         ":status",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/gutil/proto.cc
+++ b/gutil/proto.cc
@@ -17,10 +17,10 @@
 #include <fcntl.h>
 
 #include <string>
-#include <string_view>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/message.h"
@@ -29,7 +29,7 @@
 
 namespace gutil {
 
-absl::Status ReadProtoFromFile(std::string_view filename,
+absl::Status ReadProtoFromFile(absl::string_view filename,
                                google::protobuf::Message *message) {
   // Verifies that the version of the library that we linked against is
   // compatible with the version of the headers we compiled against.
@@ -51,7 +51,7 @@ absl::Status ReadProtoFromFile(std::string_view filename,
   return absl::OkStatus();
 }
 
-absl::Status ReadProtoFromString(std::string_view proto_string,
+absl::Status ReadProtoFromString(absl::string_view proto_string,
                                  google::protobuf::Message *message) {
   // Verifies that the version of the library that we linked against is
   // compatible with the version of the headers we compiled against.

--- a/gutil/proto.h
+++ b/gutil/proto.h
@@ -16,21 +16,21 @@
 #define GUTIL_PROTO_H
 
 #include <string>
-#include <string_view>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "google/protobuf/message.h"
 #include "gutil/status.h"
 
 namespace gutil {
 
 // Read the contents of the file into a protobuf.
-absl::Status ReadProtoFromFile(std::string_view filename,
+absl::Status ReadProtoFromFile(absl::string_view filename,
                                google::protobuf::Message *message);
 
 // Read the contents of the string into a protobuf.
-absl::Status ReadProtoFromString(std::string_view proto_string,
+absl::Status ReadProtoFromString(absl::string_view proto_string,
                                  google::protobuf::Message *message);
 
 // Get the name of the oneof enum that is set.

--- a/gutil/testing.h
+++ b/gutil/testing.h
@@ -15,9 +15,8 @@
 #ifndef GUTIL_TESTING_H
 #define GUTIL_TESTING_H
 
-#include <string_view>
-
 #include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "glog/logging.h"
 #include "gutil/proto.h"
 #include "gutil/status.h"
@@ -30,7 +29,7 @@ namespace gutil {
 // Parses a protobuf from a string, and crashes if parsing failed. Only use in
 // tests.
 template <typename T>
-T ParseProtoOrDie(std::string_view proto_string) {
+T ParseProtoOrDie(absl::string_view proto_string) {
   T message;
   CHECK_OK(ReadProtoFromString(proto_string, &message));
   return message;
@@ -39,7 +38,7 @@ T ParseProtoOrDie(std::string_view proto_string) {
 // Parses a protobuf from a file, and crashes if parsing failed. Only use in
 // tests.
 template <typename T>
-T ParseProtoFileOrDie(std::string_view proto_file) {
+T ParseProtoFileOrDie(absl::string_view proto_file) {
   T message;
   CHECK_OK(ReadProtoFromFile(proto_file, &message));
   return message;


### PR DESCRIPTION
This is needed because the SONiC toolchain does not yet support
std::string_view.

Change-Id: I4005bdc47c06ba82ab4607008c17fc4e971d3f4e