### PR TITLE
Cleanup test naming since gutil::StatusOr is gone.

### DIFF
--- a/gutil/status_matchers_test.cc
+++ b/gutil/status_matchers_test.cc
@@ -54,50 +54,50 @@ TEST(AbseilStatusMatcher, StatusIsWithMessageNot) {
               Not(StatusIs(absl::StatusCode::kInvalidArgument, "unknown")));
 }
 
-TEST(GutilStatusOrMatcher, IsOk) {
+TEST(AbseilStatusOrMatcher, IsOk) {
   EXPECT_THAT(absl::StatusOr<int>(1), IsOk());
 }
 
-TEST(GutilStatusOrMatcher, IsNotOk) {
+TEST(AbseilStatusOrMatcher, IsNotOk) {
   EXPECT_THAT(absl::StatusOr<int>(absl::UnknownError("unknown error")),
               Not(IsOk()));
 }
 
-TEST(GutilStatusOrMatcher, StatusIs) {
+TEST(AbseilStatusOrMatcher, StatusIs) {
   EXPECT_THAT(absl::StatusOr<int>(absl::UnknownError("unknown error")),
               StatusIs(absl::StatusCode::kUnknown));
 }
 
-TEST(GutilStatusOrMatcher, StatusIsNot) {
+TEST(AbseilStatusOrMatcher, StatusIsNot) {
   EXPECT_THAT(absl::StatusOr<int>(absl::UnknownError("unknown error")),
               Not(StatusIs(absl::StatusCode::kInvalidArgument)));
 }
 
-TEST(GutilStatusOrMatcher, StatusIsWithMessage) {
+TEST(AbseilStatusOrMatcher, StatusIsWithMessage) {
   EXPECT_THAT(absl::StatusOr<int>(absl::UnknownError("unknown error")),
               StatusIs(absl::StatusCode::kUnknown, HasSubstr("unknown")));
 }
 
-TEST(GutilStatusOrMatcher, StatusIsWithMessageNot) {
+TEST(AbseilStatusOrMatcher, StatusIsWithMessageNot) {
   EXPECT_THAT(absl::StatusOr<int>(absl::UnknownError("unknown error")),
               Not(StatusIs(absl::StatusCode::kInvalidArgument, "unknown")));
 }
 
-TEST(GutilStatusOrMatcher, StatusIsOkAndHolds) {
+TEST(AbseilStatusOrMatcher, StatusIsOkAndHolds) {
   EXPECT_THAT(absl::StatusOr<int>(1320), IsOkAndHolds(1320));
 }
 
-TEST(GutilStatusOrMatcher, StatusIsNotOkAndHolds) {
+TEST(AbseilStatusOrMatcher, StatusIsNotOkAndHolds) {
   EXPECT_THAT(absl::StatusOr<int>(1320), Not(IsOkAndHolds(0)));
 }
 
-TEST(GutilStatusOrMatcher, StatusIsOkAndHoldsWithExpectation) {
+TEST(AbseilStatusOrMatcher, StatusIsOkAndHoldsWithExpectation) {
   EXPECT_THAT(absl::StatusOr<std::string>("The quick brown fox"),
               IsOkAndHolds(HasSubstr("fox")));
 }
 
 // This test will fail to build if the macro doesn't work.
-TEST(GutilStatusOrMatcher, AssignOrReturnWorksWithMoveOnlyTypes) {
+TEST(AbseilStatusOrMatcher, AssignOrReturnWorksWithMoveOnlyTypes) {
   ASSERT_OK_AND_ASSIGN(
       auto value_from_expression,
       absl::StatusOr<std::unique_ptr<int>>(absl::make_unique<int>(0)));


### PR DESCRIPTION
Change-Id: I0497fbfcae9deb80eb6441ce6cdf2e4eb1180df1